### PR TITLE
Update build script to display a link that opens the resulting built book

### DIFF
--- a/build-product.sh
+++ b/build-product.sh
@@ -32,6 +32,7 @@ GUIDE=$1
 function buildGuide
 {
     GUIDE=$1
+    CURRENT_DIRECTORY=$(pwd)
 
     echo "***********************************************************************************************************"
     echo "$TOOL: $GUIDE"
@@ -46,13 +47,13 @@ function buildGuide
     if [ "$TOOL" = "asciidoctor" ]; then
         asciidoctor -dbook -a toc -o target/master.html target/master.adoc
         echo ""
-        echo "Built $GUIDE/target/master.html"
+        echo "Built file://$CURRENT_DIRECTORY/$GUIDE/target/master.html"
     fi
 
     if [ "$TOOL" = "ccutil" ]; then
         ccutil compile --lang en_US --format html-single --main-file target/master.adoc
         echo ""
-        echo "Built $GUIDE/build/tmp/en-US/html-single/index.html"
+        echo "Built file://$CURRENT_DIRECTORY/$GUIDE/build/tmp/en-US/html-single/index.html"
     fi
    
     cd ..


### PR DESCRIPTION
@stianst : your updates look great to me and definitely simplify things. This update just allows you to click on the resulting link in the terminal to view the built book.

One other suggestion would be to define all of the book titles in the JSON files and use those rather than hard-code them in SUMMARY.adoc each book. That way, all external references to the book will match, and if a book title needs to change, you can do it in the one place.